### PR TITLE
Integrate Redis and Celery

### DIFF
--- a/app/django-doubtfire-api/api/__init__.py
+++ b/app/django-doubtfire-api/api/__init__.py
@@ -1,0 +1,3 @@
+from api.celery import app as celery_app
+
+__all__ = ("celery_app",)

--- a/app/django-doubtfire-api/api/celery.py
+++ b/app/django-doubtfire-api/api/celery.py
@@ -1,0 +1,9 @@
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "api.settings")
+
+app = Celery("django_doubtfire_api")
+app.config_from_object("django.conf:settings", namespace="CELERY")
+app.autodiscover_tasks()

--- a/app/django-doubtfire-api/api/settings.py
+++ b/app/django-doubtfire-api/api/settings.py
@@ -104,7 +104,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ]
 
 # Redis
-REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+REDIS_URL = os.getenv("REDIS_URL")
 
 # Caching
 # https://docs.djangoproject.com/en/3.2/topics/cache/

--- a/app/django-doubtfire-api/api/settings.py
+++ b/app/django-doubtfire-api/api/settings.py
@@ -103,6 +103,29 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+# Redis
+REDIS_URL = os.getenv("REDIS_URL", "redis://redis:6379/0")
+
+# Caching
+# https://docs.djangoproject.com/en/3.2/topics/cache/
+CACHES = {
+    "default": {
+        "BACKEND": "django_redis.cache.RedisCache",
+        "LOCATION": REDIS_URL,
+        "OPTIONS": {
+            "CLIENT_CLASS": "django_redis.client.DefaultClient"
+        }
+    }
+}
+
+# Celery
+# https://docs.celeryproject.org/en/stable/userguide/configuration.html
+CELERY_BROKER_URL = REDIS_URL
+CELERY_RESULT_BACKEND = REDIS_URL
+CELERY_ACCEPT_CONTENT = ['json']
+CELERY_TASK_SERIALIZER = 'json'
+CELERY_RESULT_SERIALIZER = 'json'
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/app/django-doubtfire-api/endpoint/tasks.py
+++ b/app/django-doubtfire-api/endpoint/tasks.py
@@ -1,0 +1,5 @@
+from celery import shared_task
+
+@shared_task
+def test(param):
+    return 'The test task executed with argument "%s" ' % param

--- a/app/django-doubtfire-api/endpoint/urls.py
+++ b/app/django-doubtfire-api/endpoint/urls.py
@@ -5,4 +5,5 @@ from endpoint.views import enroll_user, validate_recording
 urlpatterns = [
     path('enroll', enroll_user),
     path('validate', validate_recording),
+    path("up", views.up, name="up"),
 ]

--- a/app/django-doubtfire-api/endpoint/urls.py
+++ b/app/django-doubtfire-api/endpoint/urls.py
@@ -1,9 +1,9 @@
 from django.urls import include, path
 from django.conf.urls import url
-from endpoint.views import enroll_user, validate_recording, up
+from endpoint.views import enroll_user, validate_recording, redis_healthcheck
 
 urlpatterns = [
     path('enroll', enroll_user),
     path('validate', validate_recording),
-    path("up", up, name="up"),
+    path("redis-healthcheck", redis_healthcheck, name="up"),
 ]

--- a/app/django-doubtfire-api/endpoint/urls.py
+++ b/app/django-doubtfire-api/endpoint/urls.py
@@ -1,9 +1,9 @@
 from django.urls import include, path
 from django.conf.urls import url
-from endpoint.views import enroll_user, validate_recording
+from endpoint.views import enroll_user, validate_recording, up
 
 urlpatterns = [
     path('enroll', enroll_user),
     path('validate', validate_recording),
-    path("up", views.up, name="up"),
+    path("up", up, name="up"),
 ]

--- a/app/django-doubtfire-api/endpoint/views.py
+++ b/app/django-doubtfire-api/endpoint/views.py
@@ -67,8 +67,8 @@ def validate_recording(request):
     return JsonResponse(response_data)
 
 # Test Redis
-def up(request):
+def redis_healthcheck(request):
     get_redis_connection().ping()
     connection.ensure_connection()
 
-    return HttpResponse("")
+    return HttpResponse("Redis is connected successfully")

--- a/app/django-doubtfire-api/endpoint/views.py
+++ b/app/django-doubtfire-api/endpoint/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ObjectDoesNotExist
-from django.db import IntegrityError, DataError
+from django.db import IntegrityError, DataError, connection
 from django_redis import get_redis_connection
 
 from endpoint.services.speaker_wrapper import speaker_wrapper_enroll_user, speaker_wrapper_validate_recording

--- a/app/django-doubtfire-api/endpoint/views.py
+++ b/app/django-doubtfire-api/endpoint/views.py
@@ -1,8 +1,9 @@
 from django.shortcuts import render
-from django.http import JsonResponse
+from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, DataError
+from django_redis import get_redis_connection
 
 from endpoint.services.speaker_wrapper import speaker_wrapper_enroll_user, speaker_wrapper_validate_recording
 
@@ -64,3 +65,10 @@ def validate_recording(request):
 
       
     return JsonResponse(response_data)
+
+# Test Redis
+def up(request):
+    get_redis_connection().ping()
+    connection.ensure_connection()
+
+    return HttpResponse("")

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -4,12 +4,14 @@ astunparse==1.6.3
 attrs==20.3.0
 audioread==2.1.9
 cachetools==4.2.1
+celery==5.0.5
 certifi==2020.12.5
 cffi==1.14.5
 chardet==4.0.0
 decorator==4.4.2
 Django==3.1.7
 djangorestframework==3.12.4
+django-redis==4.12.1
 gast==0.3.3
 google-auth==1.28.0
 google-auth-oauthlib==0.4.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   web:
@@ -16,6 +16,13 @@ services:
       - postgres_data:/var/lib/postgresql/data/
     env_file:
       - ./.env.dev.db
+  redis:
+    image: redis:6.0.10-buster
+    volumes: 
+      - redis:/data
+    env_file:
+      - ./.env.dev
 
 volumes:
   postgres_data:
+  redis: {}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,4 +25,4 @@ services:
 
 volumes:
   postgres_data:
-  redis: {}
+  redis: 

--- a/sample_envs/.env.dev.sample
+++ b/sample_envs/.env.dev.sample
@@ -8,3 +8,4 @@ SQL_PASSWORD=
 SQL_HOST=db
 SQL_PORT=5432
 DATABASE=postgres
+REDIS_URL=redis://redis:6379/0


### PR DESCRIPTION
__Files changed:__
  - `docker-compose.yml`: Add Redis service
  - `requirement.txt`: Add two Python dependencies, `celery==5.0.5` and `django-redis==4.12.1`
  - `/api/__init__.py`: Instantiate the Celery app every time Django application is started
  - `/api/settings.py`: Configure variables for Redis and Celery when working with the Django application
  - `/endpoint/urls.py`: Add path `up` to test Redis connection
  - `/endpoint/views.py`: Define function `up` to test Redis connection

__Files created:__
  - `/api/celery.py`: Define the Celery application for instantiation
  - `/endpoint/tasks.py`: Define the first Celery task to test 

Please comment feedback below for further improvements.

Ref issue #1 