### PR TITLE
Flower Monitor Supports to Track Task's State

### DIFF
--- a/app/django-doubtfire-api/api/settings.py
+++ b/app/django-doubtfire-api/api/settings.py
@@ -120,6 +120,9 @@ CACHES = {
 CELERY_BROKER_URL = REDIS_URL
 CELERY_RESULT_BACKEND = REDIS_URL
 
+# Flower Dashboard
+FLOWER_URL = os.environ.get("FLOWER_URL")
+
 
 # Internationalization
 # https://docs.djangoproject.com/en/3.1/topics/i18n/

--- a/app/django-doubtfire-api/endpoint/urls.py
+++ b/app/django-doubtfire-api/endpoint/urls.py
@@ -1,9 +1,15 @@
 from django.urls import include, path
 from django.conf.urls import url
-from endpoint.views import enroll_user, validate_recording, redis_healthcheck
+from endpoint.views import (
+    enroll_user,
+    validate_recording,
+    check_redis_health,
+    redirect_flower_dashboard,
+)
 
 urlpatterns = [
     path("enroll", enroll_user),
     path("validate", validate_recording),
-    path("redis-healthcheck", redis_healthcheck, name="up"),
+    path("redis-healthcheck", check_redis_health, name="up"),
+    path("flower", redirect_flower_dashboard),
 ]

--- a/app/django-doubtfire-api/endpoint/views.py
+++ b/app/django-doubtfire-api/endpoint/views.py
@@ -1,10 +1,11 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import JsonResponse, HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.core.exceptions import ObjectDoesNotExist
 from django.db import IntegrityError, DataError, connection
 from django_redis import get_redis_connection
 from endpoint.tasks import celery_enroll_user, celery_validate_user
+from django.conf import settings
 
 import json
 import urllib.error
@@ -67,9 +68,14 @@ def validate_recording(request):
         return JsonResponse(response_data)
 
 
-# Test Redis
-def redis_healthcheck(request):
+def check_redis_health(request):
     get_redis_connection().ping()
     connection.ensure_connection()
 
     return HttpResponse("Redis is connected successfully")
+
+
+def redirect_flower_dashboard(request):
+    FLOWER_URL = settings.FLOWER_URL
+
+    return redirect(FLOWER_URL)

--- a/app/django-doubtfire-api/requirements.txt
+++ b/app/django-doubtfire-api/requirements.txt
@@ -4,7 +4,7 @@ astunparse==1.6.3
 attrs==20.3.0
 audioread==2.1.9
 cachetools==4.2.1
-celery==5.0.5
+celery==4.4.7
 certifi==2020.12.5
 cffi==1.14.5
 chardet==4.0.0
@@ -12,6 +12,7 @@ decorator==4.4.2
 Django==3.1.7
 djangorestframework==3.12.4
 django-redis==4.12.1
+flower==0.9.7
 gast==0.3.3
 google-auth==1.28.0
 google-auth-oauthlib==0.4.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,13 @@ services:
     build: ./app/django-doubtfire-api/
     command: >
         bash -c "python3 manage.py runserver 0.0.0.0:8000 
-        & celery -A api worker --loglevel=INFO"
+        & celery -A api worker --loglevel=INFO
+        & celery flower -A api --address=0.0.0.0 --port=5555"
     volumes:
       - ./app/django-doubtfire-api/:/usr/src/app/
     ports:
       - 8000:8000
+      - 5555:5555
     env_file:
       - ./.env.dev
   db:

--- a/sample_envs/.env.dev.sample
+++ b/sample_envs/.env.dev.sample
@@ -18,3 +18,6 @@ REDIS_URL=redis://redis:6379/0
 # Celery
 CELERY_BROKER_URL=${REDIS_URL}
 CELERY_RESULT_BACKEND=${REDIS_URL}
+
+# Flower Dashboard
+FLOWER_URL=http://localhost:5555/


### PR DESCRIPTION
__Files Changed__:
- `requirements.txt`: Downgrade celery to 4.4.7 and add flower 0.9.7
- `docker-compose.yml`: Add command to run the Flower server
- `settings.py` and `.env.dev.sample`: Add `FLOWER_URL` environment variable
- `endpoints/urls.py` and `endpoints/views.py`: Add path to redirect to Flower dashboard

To access the Flower dashboard, opening `http://localhost:8000/flower` redirects to `http://localhost:5555/` that renders the Flower view. 

__Note__: The reason why the Celery package is downgraded to 4.4.7 is that the Flower package is only compatible with the Celery 4.4.x

Please comment feedback below for further improvements.

Ref #10 